### PR TITLE
renamed chunk constant

### DIFF
--- a/src/muqsit/vanillagenerator/generator/NetherGenerator.php
+++ b/src/muqsit/vanillagenerator/generator/NetherGenerator.php
@@ -101,7 +101,7 @@ class NetherGenerator extends Generator
 			if ($dirtyEntry) {
 				$c = $world->getChunk($x, $z);
 
-				$c->setTerrainDirtyFlag(Chunk::DIRTY_FLAG_TERRAIN, true);
+				$c->setTerrainDirtyFlag(Chunk::DIRTY_FLAG_BLOCKS, true);
 				$c->setTerrainDirtyFlag(Chunk::DIRTY_FLAG_BIOMES, true);
 			}
 		}

--- a/src/muqsit/vanillagenerator/generator/OverworldGenerator.php
+++ b/src/muqsit/vanillagenerator/generator/OverworldGenerator.php
@@ -121,7 +121,7 @@ class OverworldGenerator extends Generator
 			if ($dirtyEntry) {
 				$c = $world->getChunk($x, $z);
 
-				$c->setTerrainDirtyFlag(Chunk::DIRTY_FLAG_TERRAIN, true);
+				$c->setTerrainDirtyFlag(Chunk::DIRTY_FLAG_BLOCKS, true);
 				$c->setTerrainDirtyFlag(Chunk::DIRTY_FLAG_BIOMES, true);
 			}
 		}


### PR DESCRIPTION
The constant Chunk::DIRTY_FLAG_TERRAIN was renamed to Chunk::DIRTY_FLAG_BLOCKS in PocketMine-MP in commit https://github.com/pmmp/PocketMine-MP/commit/d410db4302855b9df05d17b84a4300db4aa5ca84.
This PR renames the constant in this project.